### PR TITLE
Fix PowerShell parsing failures in Windows build script

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -15,18 +15,18 @@ function Invoke-Step {
     Write-Host "`n==> $Name" -ForegroundColor Cyan
     & $Action
     if ($LASTEXITCODE -ne 0) {
-        throw "步骤失败: $Name"
+        throw "Step failed: $Name"
     }
 }
 
 if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
-    throw "未检测到 dotnet SDK。请先安装 .NET 8 SDK: https://dotnet.microsoft.com/download/dotnet/8.0"
+    throw "dotnet SDK not found. Install .NET 8 SDK first: https://dotnet.microsoft.com/download/dotnet/8.0"
 }
 
 $sdkVersion = (& dotnet --version).Trim()
 $sdkMajor = [int]($sdkVersion.Split('.')[0])
 if ($sdkMajor -lt 8) {
-    throw "当前 dotnet SDK 版本为 $sdkVersion，需 .NET 8 或更高版本。"
+    throw "Current dotnet SDK version is $sdkVersion. .NET 8 or later is required."
 }
 
 $root = Split-Path -Parent $PSScriptRoot
@@ -67,12 +67,12 @@ Copy-Item -Path (Join-Path $publishDir "*") -Destination $distDir -Recurse -Forc
 
 $exePath = Join-Path $distDir "GlassFactory.BillTracker.App.exe"
 if (-not (Test-Path $exePath)) {
-    throw "发布完成但未找到 exe：$exePath"
+    throw "Publish completed, but exe not found: $exePath"
 }
 
 $exeSizeMb = [Math]::Round(((Get-Item $exePath).Length / 1MB), 2)
 
-Write-Host "`n发布成功。" -ForegroundColor Green
+Write-Host "`nPublish succeeded." -ForegroundColor Green
 Write-Host "Runtime      : $Runtime"
 Write-Host "Configuration: $Configuration"
 Write-Host "Dist Dir     : $distDir"


### PR DESCRIPTION
### Motivation
- Prevent PowerShell parser errors on Windows caused by encoding-sensitive, non-ASCII message literals in the build script which in some environments can make subsequent lines be parsed as part of a string or block.

### Description
- Replaced localized/non-ASCII message literals in `scripts/build_windows.ps1` with ASCII-only English text so tokenization is robust across environments. 
- Only message strings were changed (`throw` messages and the final `Write-Host`), and no build logic or control flow was modified.
- Modified file: `scripts/build_windows.ps1` (error and success messages converted to ASCII). 

### Testing
- Ran a UTF-8 scan with Python to confirm there are no remaining non-ASCII characters in `scripts/build_windows.ps1`, which returned zero non-ASCII lines. 
- Attempted a PowerShell parse check using `pwsh`, but `pwsh` is not installed in this environment so an actual parser validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51fc08f908332a6350a6699c6e2e4)