### PR TITLE
Translate PowerShell script messages to English in build and smoke-check scripts

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -15,18 +15,18 @@ function Invoke-Step {
     Write-Host "`n==> $Name" -ForegroundColor Cyan
     & $Action
     if ($LASTEXITCODE -ne 0) {
-        throw "步骤失败: $Name"
+        throw "Step failed: $Name"
     }
 }
 
 if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
-    throw "未检测到 dotnet SDK。请先安装 .NET 8 SDK: https://dotnet.microsoft.com/download/dotnet/8.0"
+    throw "dotnet SDK not found. Install .NET 8 SDK first: https://dotnet.microsoft.com/download/dotnet/8.0"
 }
 
 $sdkVersion = (& dotnet --version).Trim()
 $sdkMajor = [int]($sdkVersion.Split('.')[0])
 if ($sdkMajor -lt 8) {
-    throw "当前 dotnet SDK 版本为 $sdkVersion，需 .NET 8 或更高版本。"
+    throw "Current dotnet SDK version is $sdkVersion. .NET 8 or later is required."
 }
 
 $root = Split-Path -Parent $PSScriptRoot
@@ -67,12 +67,12 @@ Copy-Item -Path (Join-Path $publishDir "*") -Destination $distDir -Recurse -Forc
 
 $exePath = Join-Path $distDir "GlassFactory.BillTracker.App.exe"
 if (-not (Test-Path $exePath)) {
-    throw "发布完成但未找到 exe：$exePath"
+    throw "Publish completed, but exe not found: $exePath"
 }
 
 $exeSizeMb = [Math]::Round(((Get-Item $exePath).Length / 1MB), 2)
 
-Write-Host "`n发布成功。" -ForegroundColor Green
+Write-Host "`nPublish succeeded." -ForegroundColor Green
 Write-Host "Runtime      : $Runtime"
 Write-Host "Configuration: $Configuration"
 Write-Host "Dist Dir     : $distDir"

--- a/scripts/publish_smoke_check.ps1
+++ b/scripts/publish_smoke_check.ps1
@@ -10,25 +10,25 @@ $root = Split-Path -Parent $PSScriptRoot
 $exePath = Join-Path $root "dist/$Runtime/GlassFactory.BillTracker.App.exe"
 
 if (-not (Test-Path $exePath)) {
-    throw "未找到发布产物：$exePath。请先执行 scripts/build_windows.ps1。"
+    throw "Publish artifact not found: $exePath. Run scripts/build_windows.ps1 first."
 }
 
 if ([string]::IsNullOrWhiteSpace($DataDir)) {
     $DataDir = Join-Path $env:TEMP "GlassFactoryBillTracker_PublishSmoke"
 }
 
-Write-Host "检测到 EXE: $exePath" -ForegroundColor Green
-Write-Host "执行 DbSmokeTest, DataDir=$DataDir" -ForegroundColor Cyan
+Write-Host "Detected EXE: $exePath" -ForegroundColor Green
+Write-Host "Running DbSmokeTest, DataDir=$DataDir" -ForegroundColor Cyan
 
 $smokeOutput = dotnet run --project (Join-Path $root "tools/GlassFactory.BillTracker.DbSmokeTest/GlassFactory.BillTracker.DbSmokeTest.csproj") -- $DataDir
 $smokeOutput | ForEach-Object { Write-Host $_ }
 
 if ($LASTEXITCODE -ne 0) {
-    throw "DbSmokeTest 执行失败。"
+    throw "DbSmokeTest failed."
 }
 
 if (-not ($smokeOutput -join "`n").Contains("SMOKE_TEST_PASS")) {
-    throw "未检测到 SMOKE_TEST_PASS。"
+    throw "SMOKE_TEST_PASS marker was not found."
 }
 
 Write-Host "Publish smoke check passed." -ForegroundColor Green


### PR DESCRIPTION
### Motivation
- Standardize console and error messages in `scripts/build_windows.ps1` and `scripts/publish_smoke_check.ps1` to English for consistent, readable output across environments.

### Description
- Replace Chinese output and error strings with English equivalents in `scripts/build_windows.ps1` and `scripts/publish_smoke_check.ps1` without altering any control flow or logic.

### Testing
- Executed the project's automated test invocation via `scripts/build_windows.ps1`, which runs `dotnet restore`, `dotnet build`, and `dotnet test`, and the CI/unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51fc08f908332a6350a6699c6e2e4)